### PR TITLE
Fix a call of overloaded 'map(double&, int, int, int, int)' is ambiguous

### DIFF
--- a/src/CO2Sensor.cpp
+++ b/src/CO2Sensor.cpp
@@ -53,7 +53,7 @@ int CO2Sensor::read(){
   if (_co2ppm<CO2_LOW) _greenLevel = 255;
   else {
     if (_co2ppm>CO2_HIGHT) _greenLevel = 0;
-    else _greenLevel = map(_co2ppm, CO2_LOW, CO2_HIGHT, 255, 0);
+    else _greenLevel = map((int)_co2ppm, CO2_LOW, CO2_HIGHT, 255, 0);
   }
 
   return _co2ppm;


### PR DESCRIPTION
This change solves following error:

```
Processing  co2-unit.ino
make -C ../modules/photon/user-part all
make[1]: Entering directory '/firmware/modules/photon/user-part'
make -C ../../../user 
make[2]: Entering directory '/firmware/user'
Building cpp file: co2-unit.cpp
Invoking: ARM GCC CPP Compiler
mkdir -p ../build/target/user/platform-6-m
arm-none-eabi-gcc -DSTM32_DEVICE -DSTM32F2XX -DPLATFORM_THREADING=1 -DPLATFORM_ID=6 -DPLATFORM_NAME=photon -DUSBD_VID_SPARK=0x2B04 -DUSBD_PID_DFU=0xD006 -DUSBD_PID_CDC=0xC006 -DSPARK_PLATFORM -g3 -gdwarf-2 -Os -mcpu=cortex-m3 -mthumb -DINCLUDE_PLATFORM=1 -DPRODUCT_ID=6 -DPRODUCT_FIRMWARE_VERSION=65535 -DUSE_STDPERIPH_DRIVER -DDFU_BUILD_ENABLE -DSYSTEM_VERSION_STRING=1.5.2 -DRELEASE_BUILD -I./inc -I../wiring/inc -I../system/inc -I../third_party/miniz/miniz -I../services/inc -I../third_party/nanopb/nanopb -I../communication/inc -I../hal/inc -I../hal/shared -I../hal/src/photon -I../hal/src/stm32f2xx -I../hal/src/stm32 -I../hal/src/photon/api -I../hal/src/photon/include -I../hal/src/photon/wiced/security/BESL/host/WICED/ -I../hal/src/photon/wiced/security/BESL/include -I../hal/src/photon/wiced/security/BESL -I../hal/src/photon/wiced/security/BESL/crypto -I../hal/src/photon/wiced/WWD/include/ -I../hal/src/photon/wiced/platform/include/ -I../hal/src/photon/wiced/platform/GCC/ -I../hal/src/photon/wiced/security/BESL/supplicant/ -I../hal/src/photon/libraries/crypto -I../hal/src/photon/libraries/daemons/DNS_redirect -I../platform/shared/inc -I../platform/MCU/STM32F2xx/STM32_USB_Host_Driver/inc -I../platform/MCU/STM32F2xx/STM32_USB_OTG_Driver/inc -I../platform/MCU/STM32F2xx/STM32_StdPeriph_Driver/inc -I../platform/MCU/STM32F2xx/STM32_USB_Device_Driver/inc -I../platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc -I../platform/MCU/shared/STM32/inc -I../platform/MCU/STM32F2xx/CMSIS/Include -I../platform/MCU/STM32F2xx/CMSIS/Device/ST/Include -I../dynalib/inc -I -I./libraries -I. -MD -MP -MF ../build/target/user/platform-6-mco2-unit.o.d -ffunction-sections -fdata-sections -Wall -Wno-switch -Wno-error=deprecated-declarations -fmessage-length=0 -fno-strict-aliasing -DSPARK=1 -DPARTICLE=1 -Wundef -DSTART_DFU_FLASHER_SERIAL_SPEED=14400 -DSTART_YMODEM_FLASHER_SERIAL_SPEED=28800 -DBOOTLOADER_SDK_3_3_0_PARTICLE -DPARTICLE_DCT_COMPATIBILITY -DSPARK_PLATFORM_NET=BCM9WCDUSI09 -fno-builtin-malloc -fno-builtin-free -fno-builtin-realloc  -DLOG_INCLUDE_SOURCE_INFO=1 -DPARTICLE_USER_MODULE -DUSER_FIRMWARE_IMAGE_SIZE=0x20000 -DUSER_FIRMWARE_IMAGE_LOCATION=0x80A0000 -DMODULAR_FIRMWARE=1 -DMODULE_VERSION=6 -DMODULE_FUNCTION=5 -DMODULE_INDEX=1 -DMODULE_DEPENDENCY=4,2,1512 -DMODULE_DEPENDENCY2=0,0,0 -D_GNU_SOURCE -DLOG_MODULE_CATEGORY="\"app\""  -fno-exceptions -fno-rtti -fcheck-new -std=gnu++14 -c -o ../build/target/user/platform-6-mco2-unit.o co2-unit.cpp

Building cpp file: CO2Sensor.cpp
Invoking: ARM GCC CPP Compiler
mkdir -p ../build/target/user/platform-6-m
arm-none-eabi-gcc -DSTM32_DEVICE -DSTM32F2XX -DPLATFORM_THREADING=1 -DPLATFORM_ID=6 -DPLATFORM_NAME=photon -DUSBD_VID_SPARK=0x2B04 -DUSBD_PID_DFU=0xD006 -DUSBD_PID_CDC=0xC006 -DSPARK_PLATFORM -g3 -gdwarf-2 -Os -mcpu=cortex-m3 -mthumb -DINCLUDE_PLATFORM=1 -DPRODUCT_ID=6 -DPRODUCT_FIRMWARE_VERSION=65535 -DUSE_STDPERIPH_DRIVER -DDFU_BUILD_ENABLE -DSYSTEM_VERSION_STRING=1.5.2 -DRELEASE_BUILD -I./inc -I../wiring/inc -I../system/inc -I../third_party/miniz/miniz -I../services/inc -I../third_party/nanopb/nanopb -I../communication/inc -I../hal/inc -I../hal/shared -I../hal/src/photon -I../hal/src/stm32f2xx -I../hal/src/stm32 -I../hal/src/photon/api -I../hal/src/photon/include -I../hal/src/photon/wiced/security/BESL/host/WICED/ -I../hal/src/photon/wiced/security/BESL/include -I../hal/src/photon/wiced/security/BESL -I../hal/src/photon/wiced/security/BESL/crypto -I../hal/src/photon/wiced/WWD/include/ -I../hal/src/photon/wiced/platform/include/ -I../hal/src/photon/wiced/platform/GCC/ -I../hal/src/photon/wiced/security/BESL/supplicant/ -I../hal/src/photon/libraries/crypto -I../hal/src/photon/libraries/daemons/DNS_redirect -I../platform/shared/inc -I../platform/MCU/STM32F2xx/STM32_USB_Host_Driver/inc -I../platform/MCU/STM32F2xx/STM32_USB_OTG_Driver/inc -I../platform/MCU/STM32F2xx/STM32_StdPeriph_Driver/inc -I../platform/MCU/STM32F2xx/STM32_USB_Device_Driver/inc -I../platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc -I../platform/MCU/shared/STM32/inc -I../platform/MCU/STM32F2xx/CMSIS/Include -I../platform/MCU/STM32F2xx/CMSIS/Device/ST/Include -I../dynalib/inc -I -I./libraries -I. -MD -MP -MF ../build/target/user/platform-6-mCO2Sensor.o.d -ffunction-sections -fdata-sections -Wall -Wno-switch -Wno-error=deprecated-declarations -fmessage-length=0 -fno-strict-aliasing -DSPARK=1 -DPARTICLE=1 -Wundef -DSTART_DFU_FLASHER_SERIAL_SPEED=14400 -DSTART_YMODEM_FLASHER_SERIAL_SPEED=28800 -DBOOTLOADER_SDK_3_3_0_PARTICLE -DPARTICLE_DCT_COMPATIBILITY -DSPARK_PLATFORM_NET=BCM9WCDUSI09 -fno-builtin-malloc -fno-builtin-free -fno-builtin-realloc  -DLOG_INCLUDE_SOURCE_INFO=1 -DPARTICLE_USER_MODULE -DUSER_FIRMWARE_IMAGE_SIZE=0x20000 -DUSER_FIRMWARE_IMAGE_LOCATION=0x80A0000 -DMODULAR_FIRMWARE=1 -DMODULE_VERSION=6 -DMODULE_FUNCTION=5 -DMODULE_INDEX=1 -DMODULE_DEPENDENCY=4,2,1512 -DMODULE_DEPENDENCY2=0,0,0 -D_GNU_SOURCE -DLOG_MODULE_CATEGORY="\"app\""  -fno-exceptions -fno-rtti -fcheck-new -std=gnu++14 -c -o ../build/target/user/platform-6-mCO2Sensor.o CO2Sensor.cpp
CO2Sensor.cpp: In member function 'int CO2Sensor::read()':
CO2Sensor.cpp:56:63: error: call of overloaded 'map(double&, int, int, int, int)' is ambiguous
     else _greenLevel = map(_co2ppm, CO2_LOW, CO2_HIGHT, 255, 0);
                                                               ^
In file included from ./inc/application.h:42:0,
                 from ./inc/Particle.h:5,
                 from ./inc/Arduino.h:11,
                 from CO2Sensor.h:9,
                 from CO2Sensor.cpp:1:
../wiring/inc/spark_wiring.h:97:5: note: candidate: int map(int, int, int, int, int)
 int map(int value, int fromStart, int fromEnd, int toStart, int toEnd);
     ^
../wiring/inc/spark_wiring.h:98:8: note: candidate: double map(double, double, double, double, double)
 double map(double value, double fromStart, double fromEnd, double toStart, double toEnd);
        ^
../build/module.mk:274: recipe for target '../build/target/user/platform-6-mCO2Sensor.o' failed
make[2]: *** [../build/target/user/platform-6-mCO2Sensor.o] Error 1
make[2]: Leaving directory '/firmware/user'
../../../build/recurse.mk:11: recipe for target 'user' failed
make[1]: *** [user] Error 2
make[1]: Leaving directory '/firmware/modules/photon/user-part'
../build/recurse.mk:11: recipe for target 'modules/photon/user-part' failed
make: *** [modules/photon/user-part] Error 2
```